### PR TITLE
Implement converters to transfer transaction

### DIFF
--- a/verification/src/agents/factorial_driver.sv
+++ b/verification/src/agents/factorial_driver.sv
@@ -20,8 +20,8 @@ class factorial_driver extends uvm_driver #(factorial_seq_item #(IN_DATA_WD, OUT
             seq_item_port.get_next_item(in_tr);
             @(posedge vif.clk);
             if (vif.resetn === 1'b1) begin
-				vif.in_data = in_tr.in_data[2:1];
-				vif.in_valid = in_tr.in_data[0];
+				vif.in_data = in_tr.in_data;
+				vif.in_valid = in_tr.in_valid;
 			end
 			else begin
 				vif.in_valid = 'h0;

--- a/verification/src/agents/factorial_in_monitor.sv
+++ b/verification/src/agents/factorial_in_monitor.sv
@@ -21,7 +21,7 @@ class factorial_in_monitor extends uvm_monitor;
         forever begin
             @(posedge vif.clk);
             wait(vif.resetn === 1'b1);
-			in_tr.in_data = {vif.in_data, vif.in_valid};
+			in_tr.in_data = vif.in_data;
             in_tr.in_valid = vif.in_valid;
             mon_in_port.write(in_tr);
         end

--- a/verification/src/agents/factorial_seq_item.sv
+++ b/verification/src/agents/factorial_seq_item.sv
@@ -1,4 +1,5 @@
 class factorial_seq_item #(int IN_DATA_WD = 3, OUT_DATA_WD = 16) extends uvm_sequence_item;
+    `uvm_object_param_utils(factorial_seq_item #(IN_DATA_WD, OUT_DATA_WD))
 
     rand bit in_valid;
     rand bit [IN_DATA_WD-1:0] in_data;
@@ -7,16 +8,24 @@ class factorial_seq_item #(int IN_DATA_WD = 3, OUT_DATA_WD = 16) extends uvm_seq
     rand bit out_busy;
 
     constraint in_valid_generation {in_valid dist {1:=80, 0:=20}; }
-    constraint in_data_generation {in_data[IN_DATA_WD-1:1] != 0; }
+    constraint in_data_generation {in_data != 0; } // Added to avoid 0 factorial bug
 
-    `uvm_object_param_utils_begin(factorial_seq_item #(IN_DATA_WD, OUT_DATA_WD))
-        `uvm_field_int(in_data, UVM_ALL_ON|UVM_HEX)
-        `uvm_field_int(out_data, UVM_ALL_ON|UVM_HEX)
-        `uvm_field_int(in_valid, UVM_ALL_ON|UVM_BIN)
-        `uvm_field_int(out_valid, UVM_ALL_ON|UVM_BIN)
-        `uvm_field_int(out_busy, UVM_ALL_ON|UVM_BIN)
-    `uvm_object_utils_end
-    
+    virtual function void do_pack(uvm_packer packer);
+        `uvm_pack_int(in_valid)
+        `uvm_pack_int(in_data)
+        `uvm_pack_int(out_valid)
+        `uvm_pack_int(out_busy)
+        `uvm_pack_int(out_data)
+    endfunction
+
+    virtual function void do_unpack(uvm_packer packer);
+        `uvm_unpack_int(in_valid)
+        `uvm_unpack_int(in_data)
+        `uvm_unpack_int(out_valid)
+        `uvm_unpack_int(out_busy)
+        `uvm_unpack_int(out_data)
+    endfunction
+
     function new (string name="factorial_in_seq_item");
         super.new (name);
     endfunction

--- a/verification/src/env/factorial_scoreboard.sv
+++ b/verification/src/env/factorial_scoreboard.sv
@@ -40,8 +40,8 @@ class factorial_scoreboard extends uvm_scoreboard;
                 refmod_port.get(refmod_tr);
             join			
 			match_result = comparer.compare_field("Signal: out_data",
-												   dut_tr.out_data, refmod_tr.out_data[OUT_DATA_WD-1:2], OUT_DATA_WD, UVM_DEC);
-			match_result &= comparer.compare_field("Signal: out_valid", dut_tr.out_valid, refmod_tr.out_data[1], 1);
+												   dut_tr.out_data, refmod_tr.out_data, OUT_DATA_WD, UVM_DEC);
+			match_result &= comparer.compare_field("Signal: out_valid", dut_tr.out_valid, refmod_tr.out_valid, 1);
 			match_result &= comparer.compare_field("Signal: out_busy", dut_tr.out_busy, refmod_tr.out_busy, 1);
             if (match_result) n_match++;
         end

--- a/verification/src/model/factorial_refmod.cpp
+++ b/verification/src/model/factorial_refmod.cpp
@@ -11,62 +11,72 @@ public:
 	bool in_valid;
 	sc_uint<3> in_data;
 	bool out_valid;
-	sc_uint<16> out_data;
 	bool out_busy;
+	sc_uint<16> out_data;
 };
 
 #include "uvmc.h"
 using namespace uvmc;
-UVMC_UTILS_5(tr, in_valid, in_data, out_valid, out_data, out_busy)
+
+template <>
+struct uvmc_converter<tr> {
+    static void do_pack (const tr &t, uvmc_packer &packer) {
+        packer << t.in_valid << t.in_data << t.out_valid << t.out_busy << t.out_data;
+    }
+
+    static void do_unpack (tr &t, uvmc_packer &packer) {
+        packer >> t.in_valid >> t.in_data >> t.out_valid >> t.out_busy >> t.out_data;
+    }
+};
+// UVMC_UTILS_5(tr, in_valid, in_data, out_valid, out_busy, out_data)
 
 SC_MODULE(factorial_refmod) {
-  sc_port<tlm_get_peek_if<tr> > in;
-  sc_port<tlm_put_if<tr> > out;
+    sc_port<tlm_get_peek_if<tr> > in;
+    sc_port<tlm_put_if<tr> > out;
 
 	sc_signal<bool> clk_sig;
 	sc_signal<bool> resetn_sig;
-	sc_signal<int> in_data_sig;
 	sc_signal<bool> in_valid_sig;
+	sc_signal<int> in_data_sig;
 
-	sc_signal<int> out_data_sig;
 	sc_signal<bool> out_valid_sig;
 	sc_signal<bool> out_busy_sig;
+	sc_signal<int> out_data_sig;
 
 	factorial_cpp factorial;
 
-  SC_CTOR(factorial_refmod): in("in"), out("out"), factorial("factorial") {
-		factorial.clk(clk_sig);
-		factorial.resetn(resetn_sig);
-		factorial.in_data(in_data_sig);
-		factorial.in_valid(in_valid_sig);
+    SC_CTOR(factorial_refmod): in("in"), out("out"), factorial("factorial") {
+        factorial.clk(clk_sig);
+        factorial.resetn(resetn_sig);
+        factorial.in_valid(in_valid_sig);
+        factorial.in_data(in_data_sig);
 
-		factorial.out_data(out_data_sig);
-		factorial.out_valid(out_valid_sig);
-		factorial.out_busy(out_busy_sig);
-		
-		SC_THREAD(p);
-	}
+        factorial.out_valid(out_valid_sig);
+        factorial.out_busy(out_busy_sig);
+        factorial.out_data(out_data_sig);
 
-  void p() {
-    
-    tr tr_in, tr_out;
-
-		clk_sig = 0;
-    while(1){
-			in->get(tr_in);
-
-			resetn_sig = 1;
-			in_data_sig = tr_in.in_data;
-			in_valid_sig = tr_in.in_valid;
-
-			clk_sig = 1;
-
-			tr_out.out_valid = out_valid_sig.read();
-			tr_out.out_busy = out_busy_sig.read();
-			tr_out.out_data = static_cast<unsigned int>(out_data_sig.read());
-
-			out->put(tr_out);
-			clk_sig = 0;
+        SC_THREAD(p);
     }
-  }
+
+    void p() {
+        tr tr_in, tr_out;
+
+        clk_sig = 0;
+        while(1){
+            in->get(tr_in);
+
+            resetn_sig = 1;
+            in_data_sig = tr_in.in_data;
+            in_valid_sig = tr_in.in_valid;
+
+            clk_sig = 1;
+
+            tr_out.out_valid = out_valid_sig.read();
+            tr_out.out_busy = out_busy_sig.read();
+            tr_out.out_data = static_cast<unsigned int>(out_data_sig.read());
+
+            out->put(tr_out);
+            clk_sig = 0;
+        }
+    }
 };


### PR DESCRIPTION
TB now uses uvm_pack and uvm_unpack macros on the SV side and a converter framework on the SC side to transfer transactions.